### PR TITLE
 DSND-1106: update private api sdk to change MetricsApi move-on data type to data-time and added requied convertor to fix the issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<cucumber-java.version>7.2.3</cucumber-java.version>
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<io-cucumber.version>7.2.3</io-cucumber.version>
-		<private-api-sdk-java.version>2.0.179</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.182</private-api-sdk-java.version>
 		<springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
 		<skip.integration.tests>false</skip.integration.tests>
 		<skip.unit.tests>false</skip.unit.tests>

--- a/src/main/java/uk/gov/companieshouse/company/metrics/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/config/MongoConfig.java
@@ -8,18 +8,27 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.gov.companieshouse.api.charges.ScottishAlterationsApi;
+import uk.gov.companieshouse.api.charges.TransactionsLinks;
 import uk.gov.companieshouse.company.metrics.converter.CompanyMetricsReadConverter;
 import uk.gov.companieshouse.company.metrics.converter.CompanyMetricsWriteConverter;
 import uk.gov.companieshouse.company.metrics.converter.EnumConverters;
+import uk.gov.companieshouse.company.metrics.converter.OffsetDateTimeReadConverter;
+import uk.gov.companieshouse.company.metrics.converter.OffsetDateTimeWriteConverter;
 import uk.gov.companieshouse.company.metrics.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.company.metrics.serialization.LocalDateSerializer;
 import uk.gov.companieshouse.company.metrics.serialization.LocalDateTimeDeSerializer;
 import uk.gov.companieshouse.company.metrics.serialization.LocalDateTimeSerializer;
+import uk.gov.companieshouse.company.metrics.serialization.NonBlankStringSerializer;
+import uk.gov.companieshouse.company.metrics.serialization.NotNullFieldObjectSerializer;
+import uk.gov.companieshouse.company.metrics.serialization.OffsetDateTimeDeSerializer;
+import uk.gov.companieshouse.company.metrics.serialization.OffsetDateTimeSerializer;
 
 
 @Configuration
@@ -35,7 +44,8 @@ public class MongoConfig {
         return new MongoCustomConversions(List.of(new CompanyMetricsReadConverter(objectMapper),
                 new EnumConverters.StringToEnum(),
                 new EnumConverters.EnumToString(),
-                new CompanyMetricsWriteConverter(objectMapper)));
+                new CompanyMetricsWriteConverter(objectMapper), new OffsetDateTimeReadConverter(),
+                new OffsetDateTimeWriteConverter()));
     }
 
     /**
@@ -53,6 +63,11 @@ public class MongoConfig {
         module.addDeserializer(LocalDate.class, new LocalDateDeSerializer());
         module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
         module.addDeserializer(LocalDateTime.class, new LocalDateTimeDeSerializer());
+        module.addSerializer(String.class, new NonBlankStringSerializer());
+        module.addSerializer(ScottishAlterationsApi.class, new NotNullFieldObjectSerializer());
+        module.addSerializer(TransactionsLinks.class, new NotNullFieldObjectSerializer());
+        module.addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
+        module.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeSerializer());
         objectMapper.registerModule(module);
         return objectMapper;
     }

--- a/src/main/java/uk/gov/companieshouse/company/metrics/converter/OffsetDateTimeReadConverter.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/converter/OffsetDateTimeReadConverter.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.company.metrics.converter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import org.springframework.core.convert.converter.Converter;
+
+public class OffsetDateTimeReadConverter implements Converter<Date, OffsetDateTime> {
+
+    @Override
+    public OffsetDateTime convert(final Date date) {
+        OffsetDateTime offsetDateTime = date.toInstant()
+                .atOffset(ZoneOffset.UTC);
+        return offsetDateTime;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/company/metrics/converter/OffsetDateTimeWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/converter/OffsetDateTimeWriteConverter.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.company.metrics.converter;
+
+import java.time.OffsetDateTime;
+import java.util.Date;
+import org.springframework.core.convert.converter.Converter;
+
+public class OffsetDateTimeWriteConverter implements Converter<OffsetDateTime, Date> {
+
+    @Override
+    public Date convert(final OffsetDateTime offsetDateTime) {
+
+        return Date.from(offsetDateTime.toInstant());
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/company/metrics/serialization/NonBlankStringSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/serialization/NonBlankStringSerializer.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.apache.commons.lang.StringUtils;
+
+public class NonBlankStringSerializer extends JsonSerializer<String> {
+
+    @Override
+    public void serialize(String value, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        if (isEmpty(serializerProvider, value)) {
+            jsonGenerator.writeNull();
+        } else {
+            jsonGenerator.writeString(value);
+        }
+    }
+
+    @Override
+    public boolean isEmpty(SerializerProvider provider, String value) {
+        return StringUtils.isBlank(value);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company/metrics/serialization/NotNullFieldObjectSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/serialization/NotNullFieldObjectSerializer.java
@@ -1,0 +1,48 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.commons.lang3.ObjectUtils;
+
+public class NotNullFieldObjectSerializer extends JsonSerializer<Object> {
+
+    @Override
+    public void serialize(Object value, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        if (isEmpty(serializerProvider, value)) {
+            jsonGenerator.writeNull();
+        } else {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+            jsonGenerator.writeRawValue(objectMapper.writeValueAsString(value));
+        }
+    }
+
+    @Override
+    public boolean isEmpty(SerializerProvider provider, Object value) {
+        return !isAnyFieldValueNotNull(value);
+    }
+
+    private boolean isAnyFieldValueNotNull(Object value) {
+        if (value == null) {
+            return false;
+        }
+
+        return ObjectUtils.anyNotNull(Arrays.stream(value.getClass().getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .map(field -> {
+                    try {
+                        field.setAccessible(true);
+                        return field.get(value);
+                    } catch (IllegalAccessException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }).toArray(Object[]::new));
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeDeSerializer.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+
+public class OffsetDateTimeDeSerializer extends JsonDeserializer<OffsetDateTime> {
+
+    public static final String APPLICATION_NAME_SPACE = "company-profile-api";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+
+    @Override
+    public OffsetDateTime deserialize(JsonParser jsonParser, DeserializationContext
+            deserializationContext) {
+        try {
+            JsonNode jsonNode = jsonParser.readValueAsTree();
+            return OffsetDateTime.parse(jsonNode.get("$date")
+                    .textValue(), DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (Exception exception) {
+            LOGGER.error("OffsetDateTime Deserialization failed.", exception);
+            throw new RuntimeException("Failed while deserializing "
+                    + "date value for json node.", exception);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeSerializer.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+    @Override
+    public void serialize(OffsetDateTime offsetDateTime, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        if (offsetDateTime == null) {
+            jsonGenerator.writeNull();
+        } else {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                    .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            String format = offsetDateTime.format(dateTimeFormatter);
+            jsonGenerator.writeRawValue("ISODate(\"" + format + "\")");
+
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company/metrics/serialization/NonBlankStringSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/serialization/NonBlankStringSerializerTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NonBlankStringSerializerTest {
+
+    @Mock
+    private SerializerProvider serializerProvider;
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    private NonBlankStringSerializer stringSerializer;
+
+    @BeforeEach
+    void setUp() {
+        stringSerializer = new NonBlankStringSerializer();
+    }
+
+    @Test
+    void testSerialiseNonBlankValue() throws IOException {
+        stringSerializer.serialize("test", jsonGenerator, serializerProvider);
+
+        verify(jsonGenerator).writeString("test");
+    }
+
+    @Test
+    void testSerialiseBlankValue() throws IOException {
+        stringSerializer.serialize("   ", jsonGenerator, serializerProvider);
+
+        verify(jsonGenerator).writeNull();
+    }
+
+    @Test
+    void testSerialiseNullValue() throws IOException {
+        stringSerializer.serialize(null, jsonGenerator, serializerProvider);
+
+        verify(jsonGenerator).writeNull();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company/metrics/serialization/NotNullFieldObjectSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/serialization/NotNullFieldObjectSerializerTest.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.charges.ScottishAlterationsApi;
+
+@ExtendWith(MockitoExtension.class)
+public class NotNullFieldObjectSerializerTest {
+
+    @Mock
+    private SerializerProvider serializerProvider;
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    private NotNullFieldObjectSerializer apiSerializer;
+
+    @BeforeEach
+    void setUp() {
+        apiSerializer = new NotNullFieldObjectSerializer();
+    }
+
+    @Test
+    void testSerialiseScottishAlterationsApiObject() throws IOException {
+        ScottishAlterationsApi alterationsApi = new ScottishAlterationsApi();
+        alterationsApi.setDescription("test");
+        apiSerializer.serialize(alterationsApi, jsonGenerator, serializerProvider);
+
+        verify(jsonGenerator).writeRawValue("{\"description\":\"test\"}");
+    }
+
+    @Test
+    void testEmptyScottishAlterationsApiObject() {
+        ScottishAlterationsApi alterationsApi = new ScottishAlterationsApi();
+
+        assertTrue(apiSerializer.isEmpty(serializerProvider, alterationsApi));
+        assertTrue(apiSerializer.isEmpty(serializerProvider, null));
+    }
+
+    @Test
+    void testNonEmptyScottishAlterationsApiObject() {
+        ScottishAlterationsApi alterationsApi = new ScottishAlterationsApi();
+        alterationsApi.setDescription("some description");
+        alterationsApi.setHasAlterationsToProhibitions(true);
+
+        assertFalse(apiSerializer.isEmpty(serializerProvider, alterationsApi));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeDeSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeDeSerializerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class OffsetDateTimeDeSerializerTest {
+
+    private static final String DATE_STRING = "2015-06-26T08:31:35.058Z";
+
+    @Mock
+    private DeserializationContext deserializationContext;
+    @Mock
+    private JsonParser jsonParser;
+    @Mock
+    private JsonNode jsonNode;
+
+    private OffsetDateTimeDeSerializer deserializer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        deserializer = new OffsetDateTimeDeSerializer();
+        when(jsonParser.readValueAsTree()).thenReturn(jsonNode);
+    }
+
+    @Test
+    void testDeserializeTextValue() {
+        when(jsonNode.get(any())).thenReturn(jsonNode);
+        when(jsonNode.textValue()).thenReturn(DATE_STRING);
+        OffsetDateTime offsetDateTime = deserializer.deserialize(jsonParser, deserializationContext);
+
+        assertEquals(OffsetDateTime.parse(DATE_STRING, DateTimeFormatter.ISO_OFFSET_DATE_TIME), offsetDateTime);
+    }
+
+    @Test
+    void testDeserializeWithException() {
+        when(jsonNode.get(any())).thenReturn(jsonNode);
+        when(jsonNode.textValue()).thenThrow(new IllegalStateException("exception"));
+
+        assertThrows(RuntimeException.class, () -> deserializer.deserialize(jsonParser, deserializationContext));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/serialization/OffsetDateTimeSerializerTest.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.company.metrics.serialization;
+
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class OffsetDateTimeSerializerTest {
+
+    private static final String DATE_STRING = "2015-06-26T08:31:35.058Z";
+
+    @Mock
+    private SerializerProvider serializerProvider;
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    private OffsetDateTimeSerializer serializer;
+
+    @BeforeEach
+    void setUp() {
+        serializer = new OffsetDateTimeSerializer();
+    }
+
+    @Test
+    void testSerialiseValidValue() throws IOException {
+        serializer.serialize(OffsetDateTime.parse(DATE_STRING, DateTimeFormatter.ISO_OFFSET_DATE_TIME), jsonGenerator, serializerProvider);
+
+        verify(jsonGenerator).writeRawValue("ISODate(\"2015-06-26T08:31:35.058Z\")");
+    }
+
+    @Test
+    void testSerialiseNullValue() throws IOException {
+        serializer.serialize(null, jsonGenerator, serializerProvider);
+
+        verify(jsonGenerator).writeNull();
+    }
+
+}

--- a/src/test/resources/source-bson-metrics-body-3.json
+++ b/src/test/resources/source-bson-metrics-body-3.json
@@ -1,0 +1,41 @@
+{
+  "_id" : "00006400",
+  "data" : {
+    "counts" : {
+      "appointments" : {
+        "active_directors_count" : 13,
+        "total_count" : 63,
+        "active_count" : 14,
+        "active_secretaries_count" : 1,
+        "resigned_count" : 49,
+        "active_llp_members_count" : 0
+      },
+      "persons-with-significant-control" : {
+        "active_pscs_count" : 0,
+        "active_statements_count" : 0,
+        "pscs_count" : 1,
+        "total_count" : 1,
+        "withdrawn_statements_count" : 0,
+        "ceased_pscs_count" : 1,
+        "statements_count" : 0
+      }
+    },
+    "etag" : "d9c0b4ab7fd4e88ad1fa691840134a4ad41b4ed0",
+    "mortgage" : {
+      "total_count" : 14,
+      "satisfied_count" : 14,
+      "part_satisfied_count" : 0
+    },
+    "registers" : {
+      "directors" : {
+        "register_moved_to" : "public-register",
+        "moved_on" : "2022-03-02T11:16:19.000Z"
+      }
+    }
+  },
+  "updated" : {
+    "at" : "2021-03-08T12:20:56.208Z",
+    "by" : "6046169cb4bf533b0dc227b9",
+    "type" : "company_metrics"
+  }
+}


### PR DESCRIPTION
 DSND-1106: update private api sdk to change MetricsApi move-on data type to data-time and added requied convertor to fix the issue