### PR TITLE
DSND-1541 - Change logic in the way authentication and authorisations are handled

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/metrics/steps/CompanyMetricsApiErrorRetrySteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/steps/CompanyMetricsApiErrorRetrySteps.java
@@ -63,6 +63,7 @@ public class CompanyMetricsApiErrorRetrySteps {
         headers.set("x-request-id", "5234234234");
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
         HttpEntity<MetricsRecalculateApi> request = new HttpEntity<>(metricsRecalculateApi, headers);
 
         String uri = "/company/{company_number}/metrics/recalculate";

--- a/src/itest/java/uk/gov/companieshouse/company/metrics/steps/CompanyMetricsApiSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/steps/CompanyMetricsApiSteps.java
@@ -126,6 +126,7 @@ public class CompanyMetricsApiSteps {
         headers.set("x-request-id", "5234234234");
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
         HttpEntity<MetricsRecalculateApi> request = new HttpEntity<>(metricsRecalculateApi, headers);
 
         String uri = "/company/{company_number}/metrics/recalculate";
@@ -158,6 +159,7 @@ public class CompanyMetricsApiSteps {
         headers.set("x-request-id", "5234234234");
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
         HttpEntity<MetricsRecalculateApi> request = new HttpEntity<>(metricsRecalculateApi, headers);
 
         String uri = "/company/{company_number}/metrics/recalculate";

--- a/src/itest/java/uk/gov/companieshouse/company/metrics/steps/ITestUtil.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/steps/ITestUtil.java
@@ -123,7 +123,7 @@ public class ITestUtil {
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
         headers.set("x-request-id", id);
+        headers.set("ERIC-Authorised-Key-Privileges", "internal-app");
         return headers;
     }
-
 }

--- a/src/itest/resources/features/company-metrics-api-Error-Retry.feature
+++ b/src/itest/resources/features/company-metrics-api-Error-Retry.feature
@@ -18,7 +18,7 @@ Feature: Process company metrics error and retry
   Scenario: Request without authentication headers fails to process
     Given Company metrics api rest service is running
     When I send POST request with an no auth header
-    Then Rest endpoint returns http response code 403 'Forbidden' to the client
+    Then Rest endpoint returns http response code 401 'Unauthorised' to the client
 
   Scenario Outline: Non recoverable NPE returns 500 response
     Given Company metrics api rest service is running

--- a/src/main/java/uk/gov/companieshouse/company/metrics/auth/EricTokenAuthenticationFilter.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/auth/EricTokenAuthenticationFilter.java
@@ -1,12 +1,14 @@
 package uk.gov.companieshouse.company.metrics.auth;
 
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -21,30 +23,46 @@ public class EricTokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
+
         String ericIdentity = request.getHeader("ERIC-Identity");
 
         if (StringUtils.isBlank(ericIdentity)) {
-            logger.error("Unauthorised request received without eric identity");
-            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            logger.error("Request received without eric identity");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 
         String ericIdentityType = request.getHeader("ERIC-Identity-Type");
 
-        if (StringUtils.isBlank(ericIdentityType)
-                || !(ericIdentityType.equalsIgnoreCase("key")
-                || (ericIdentityType.equalsIgnoreCase("oauth2")))) {
-            logger.error("Unauthorised request received without eric identity type");
+        if (!("key".equalsIgnoreCase(ericIdentityType)
+                || ("oauth2".equalsIgnoreCase(ericIdentityType)))) {
+            logger.error("Request received without correct eric identity type");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        if (!isKeyAuthorised(request, ericIdentityType)) {
+            logger.info("Supplied key does not have sufficient privilege for the action");
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
 
-        filterChain.doFilter(request, response);
+        filterChain.doFilter(request,response);
     }
 
-    @Override
-    protected boolean shouldNotFilterAsyncDispatch() {
-        return false;
+    private boolean isKeyAuthorised(HttpServletRequest request, String ericIdentityType) {
+        String[] privileges = getApiKeyPrivileges(request);
+
+        return request.getMethod().equals("GET")
+                || (ericIdentityType.equalsIgnoreCase("Key")
+                && ArrayUtils.contains(privileges, "internal-app"));
     }
 
+    private String[] getApiKeyPrivileges(HttpServletRequest request) {
+        String commaSeparatedPrivilegeString = request.getHeader("ERIC-Authorised-Key-Privileges");
+
+        return Optional.ofNullable(commaSeparatedPrivilegeString)
+                .map(s -> s.split(","))
+                .orElse(new String[]{});
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/company/metrics/auth/EricTokenAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/auth/EricTokenAuthenticationFilterTest.java
@@ -31,12 +31,13 @@ public class EricTokenAuthenticationFilterTest {
     FilterChain filterChain;
 
     @Test
-    @DisplayName("EricTokenAuthenticationFilter doFilterInternal Test successfully calling filterchain method")
+    @DisplayName("OAUTH2 GET request passes filter")
     void doFilterInternal() throws ServletException, IOException {
         EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
 
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+        when(request.getMethod()).thenReturn("GET");
 
         ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
@@ -44,11 +45,136 @@ public class EricTokenAuthenticationFilterTest {
     }
 
     @Test
-    @DisplayName("EricTokenAuthenticationFilter doFilterInternal Test not filter chain method when not passing proper Eric headers")
-    void doFilterInternalNoCallToFilterChain() throws ServletException, IOException {
+    @DisplayName("KEY type GET request passes filter")
+    void doFilterInternalKey() throws ServletException, IOException {
         EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
 
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getMethod()).thenReturn("GET");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("KEY type GET request with internal app privileges passes filter")
+    void doFilterInternalKeyAndInternalApp() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
+        when(request.getMethod()).thenReturn("GET");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("KEY type PUT request with internal app privileges passes filter")
+    void doFilterInternalMethodPutTypeKeyAndInternalApp() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Request with no identity fails ")
+    void doFilterInternalNoIdentity() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Request with no identity type fails ")
+    void doFilterInternalNoIdentityType() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Request with wrong identity type fails ")
+    void doFilterInternalWrongIdentityType() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("identityType");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with OAUTH2 type fails")
+    void doFilterInternalOauth2WrongMethod() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with OAUTH2 type and internal app privilege fails")
+    void doFilterInternalOauth2WrongMethodWithPrivilege() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with KEY type with no privileges fails")
+    void doFilterInternalKeyNoPrivileges() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with KEY type with wrong privileges fails")
+    void doFilterInternalKeyWrongPrivileges() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("privilege");
+        when(request.getMethod()).thenReturn("PUT");
 
         ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
 

--- a/src/test/java/uk/gov/companieshouse/company/metrics/auth/EricTokenAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/auth/EricTokenAuthenticationFilterTest.java
@@ -9,13 +9,15 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.logging.Logger;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class EricTokenAuthenticationFilterTest {
 
     @Mock
@@ -30,11 +32,16 @@ public class EricTokenAuthenticationFilterTest {
     @Mock
     FilterChain filterChain;
 
+    EricTokenAuthenticationFilter ericTokenAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+    }
+
     @Test
     @DisplayName("OAUTH2 GET request passes filter")
     void doFilterInternal() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
         when(request.getMethod()).thenReturn("GET");
@@ -47,8 +54,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("KEY type GET request passes filter")
     void doFilterInternalKey() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
         when(request.getMethod()).thenReturn("GET");
@@ -61,8 +66,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("KEY type GET request with internal app privileges passes filter")
     void doFilterInternalKeyAndInternalApp() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
         when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
@@ -76,8 +79,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("KEY type PUT request with internal app privileges passes filter")
     void doFilterInternalMethodPutTypeKeyAndInternalApp() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
         when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
@@ -91,8 +92,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("Request with no identity fails ")
     void doFilterInternalNoIdentity() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
         verify(filterChain, times(0)).doFilter(request, response);
@@ -101,8 +100,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("Request with no identity type fails ")
     void doFilterInternalNoIdentityType() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
 
         ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -113,8 +110,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("Request with wrong identity type fails ")
     void doFilterInternalWrongIdentityType() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("identityType");
 
@@ -126,8 +121,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("PUT Request with OAUTH2 type fails")
     void doFilterInternalOauth2WrongMethod() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
         when(request.getMethod()).thenReturn("PUT");
@@ -140,8 +133,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("PUT Request with OAUTH2 type and internal app privilege fails")
     void doFilterInternalOauth2WrongMethodWithPrivilege() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
         when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
@@ -155,8 +146,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("PUT Request with KEY type with no privileges fails")
     void doFilterInternalKeyNoPrivileges() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
         when(request.getMethod()).thenReturn("PUT");
@@ -169,8 +158,6 @@ public class EricTokenAuthenticationFilterTest {
     @Test
     @DisplayName("PUT Request with KEY type with wrong privileges fails")
     void doFilterInternalKeyWrongPrivileges() throws ServletException, IOException {
-        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
-
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
         when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("privilege");


### PR DESCRIPTION
* Authorise OAuth2 requests only if it calls the GET endpoint
* For Key IdentityType, check to see whether it has internal app privilege when calling recalculate

Resolves [DSND-1541](https://companieshouse.atlassian.net/browse/DSND-1541)

[DSND-1541]: https://companieshouse.atlassian.net/browse/DSND-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ