### PR TITLE
DSND-1554: Integration tests for company appointment metrics

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/metrics/config/CucumberContext.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/config/CucumberContext.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.company.metrics.config;
 
-import org.springframework.http.ResponseEntity;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +10,8 @@ public enum CucumberContext {
 
     CONTEXT;
 
-    private final ThreadLocal<Map<String, Object>> testContexts = ThreadLocal.withInitial(HashMap::new);
+    private final ThreadLocal<Map<String, Object>> testContexts = ThreadLocal.withInitial(
+            HashMap::new);
 
     public Object get(String name) {
         return testContexts.get()
@@ -23,5 +22,10 @@ public enum CucumberContext {
         testContexts.get()
                 .put(name, object);
         return object;
+    }
+
+    public void clear() {
+        testContexts.get()
+                .clear();
     }
 }

--- a/src/itest/java/uk/gov/companieshouse/company/metrics/steps/AppointmentsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/steps/AppointmentsSteps.java
@@ -389,7 +389,7 @@ public class AppointmentsSteps {
         }
 
         CompanyMetricsDocument updatedDocument = companyMetricsRepository
-                .findById(CONTEXT.get(COMPANY_NUMBER).toString()).orElseGet(() -> null);
+                .findById(CONTEXT.get(COMPANY_NUMBER).toString()).orElse(null);
         CONTEXT.set(UPDATED_DOC, updatedDocument);
     }
 

--- a/src/itest/java/uk/gov/companieshouse/company/metrics/steps/AppointmentsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/steps/AppointmentsSteps.java
@@ -1,0 +1,402 @@
+package uk.gov.companieshouse.company.metrics.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.companieshouse.company.metrics.config.AbstractMongoConfig.mongoDBContainer;
+import static uk.gov.companieshouse.company.metrics.config.CucumberContext.CONTEXT;
+
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.metrics.AppointmentsApi;
+import uk.gov.companieshouse.api.metrics.CountsApi;
+import uk.gov.companieshouse.api.metrics.InternalData;
+import uk.gov.companieshouse.api.metrics.MetricsApi;
+import uk.gov.companieshouse.api.metrics.MetricsRecalculateApi;
+import uk.gov.companieshouse.api.metrics.MortgageApi;
+import uk.gov.companieshouse.api.metrics.PscApi;
+import uk.gov.companieshouse.company.metrics.model.AppointmentDocument;
+import uk.gov.companieshouse.company.metrics.model.CompanyMetricsDocument;
+import uk.gov.companieshouse.company.metrics.model.Officer;
+import uk.gov.companieshouse.company.metrics.model.Updated;
+import uk.gov.companieshouse.company.metrics.repository.appointments.AppointmentRepository;
+import uk.gov.companieshouse.company.metrics.repository.charges.ChargesRepository;
+import uk.gov.companieshouse.company.metrics.repository.metrics.CompanyMetricsRepository;
+
+public class AppointmentsSteps {
+
+    private static final String RECALCULATE_URI = "/company/{company_number}/metrics/recalculate";
+    private static final String ERIC_IDENTITY = "ERIC-Identity";
+    private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
+    private static final String ERIC_AUTHORISED_KEY_PRIVILEGES = "ERIC-Authorised-Key-Privileges";
+    private static final String IDENTITY_TYPE_KEY = "key";
+    private static final String INTERNAL_APP_PRIVILEGES = "internal-app";
+    private static final String X_REQUEST_ID = "x-request-id";
+    private static final String COMPANY_NUMBER = "companyNumber";
+    private static final String STATUS_CODE = "statusCode";
+    private static final String LOCATION = "LOCATION";
+    private static final String RESPONSE_BODY = "RESPONSE";
+    private static final String UPDATED_DOC = "UPDATED_DOCUMENT";
+    private static final String ORIGINAL_ETAG = "ORIGINAL_ETAG";
+    private static final String DIRECTOR = "director";
+    private static final String CORPORATE_LLP_MEMBER = "corporate-llp-member";
+    private static final String SECRETARY = "secretary";
+    private static final String LLP_MEMBER = "llp-member";
+    private static final String START_TIME = "START_TIME";
+    private static final String CONTEXT_ID = "CONTEXT_ID";
+    private static final String COMPANY_METRICS_TYPE = "company_metrics";
+
+    private final ChargesRepository chargesRepository;
+
+    private final CompanyMetricsRepository companyMetricsRepository;
+
+    private final AppointmentRepository appointmentRepository;
+
+    private final TestRestTemplate restTemplate;
+
+    private final HttpHeaders headers = new HttpHeaders();
+
+    public AppointmentsSteps(ChargesRepository chargesRepository,
+            CompanyMetricsRepository companyMetricsRepository,
+            AppointmentRepository appointmentRepository, TestRestTemplate restTemplate) {
+        this.chargesRepository = chargesRepository;
+        this.companyMetricsRepository = companyMetricsRepository;
+        this.appointmentRepository = appointmentRepository;
+        this.restTemplate = restTemplate;
+    }
+
+    @Before
+    public void setup() {
+        CONTEXT.clear();
+
+        if (mongoDBContainer.getContainerId() == null) {
+            mongoDBContainer.start();
+        }
+        chargesRepository.deleteAll();
+        companyMetricsRepository.deleteAll();
+        appointmentRepository.deleteAll();
+
+        CONTEXT.set(START_TIME, LocalDateTime.now());
+    }
+
+    @Given("A company metrics resource does not exist for a company number of {string}")
+    public void companyMetricsResourceDoesNotExistsForTheGivenCompanyNumber(String companyNumber) {
+        CONTEXT.set(COMPANY_NUMBER, companyNumber);
+        CONTEXT.set(ORIGINAL_ETAG, "");
+    }
+
+    @And("The user is authenticated and authorised with internal app privileges")
+    public void userIsAuthenticatedAndAuthorisedWithInternalAppPrivileges() {
+        String contextId = UUID.randomUUID().toString();
+        CONTEXT.set(CONTEXT_ID, contextId);
+
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(X_REQUEST_ID, contextId);
+        headers.set(ERIC_IDENTITY, "SOME_IDENTITY");
+        headers.set(ERIC_IDENTITY_TYPE, IDENTITY_TYPE_KEY);
+        headers.set(ERIC_AUTHORISED_KEY_PRIVILEGES, INTERNAL_APP_PRIVILEGES);
+    }
+
+    @When("The recalculate endpoint is called by user {string}")
+    public void theRecalculateEndpointIsCalled(String updatedBy) {
+        MetricsRecalculateApi requestBody = new MetricsRecalculateApi()
+                .appointments(true)
+                .internalData(new InternalData()
+                        .updatedBy(updatedBy));
+
+        HttpEntity<MetricsRecalculateApi> request = new HttpEntity<>(requestBody, headers);
+        ResponseEntity<Void> response = restTemplate.exchange(RECALCULATE_URI, HttpMethod.POST,
+                request, Void.class, CONTEXT.get(COMPANY_NUMBER));
+        CONTEXT.set(RESPONSE_BODY, response.getBody());
+        CONTEXT.set(STATUS_CODE, response.getStatusCodeValue());
+
+        URI location = response.getHeaders().getLocation();
+        if (location != null) {
+            CONTEXT.set(LOCATION, location.toString());
+        }
+
+        CompanyMetricsDocument updatedDocument = companyMetricsRepository
+                .findById(CONTEXT.get(COMPANY_NUMBER).toString()).orElseGet(() -> null);
+        CONTEXT.set(UPDATED_DOC, updatedDocument);
+    }
+
+    @Then("The response code should be HTTP OK")
+    public void theResponseCodeShouldBeHttpOK() {
+        assertThat(CONTEXT.get(STATUS_CODE)).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @And("The location response header should be {string}")
+    public void theLocationResponseHeaderShouldBeCompanyCompany_numberMetrics(String uri) {
+        assertThat(CONTEXT.get(LOCATION)).isEqualTo(uri);
+    }
+
+    @And("The response should not include a location header")
+    public void theResponseShouldNotIncludeALocationHeader() {
+        assertThat(CONTEXT.get(LOCATION)).isNull();
+    }
+
+    @And("The response body should be empty")
+    public void theResponseBodyShouldBeEmpty() {
+        assertThat(CONTEXT.get(RESPONSE_BODY)).isNull();
+    }
+
+    @And("The metrics resource has a count.appointments object")
+    public void aNewMetricsResourceWithACountAppointmentsObjectShouldBeCreated() {
+        CompanyMetricsDocument updatedDocument = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        assertThat(updatedDocument.getCompanyMetrics()).isNotNull();
+        assertThat(updatedDocument.getCompanyMetrics().getCounts()).isNotNull();
+        assertThat(updatedDocument.getCompanyMetrics().getCounts().getAppointments()).isNotNull();
+    }
+
+    @And("The etag should be updated")
+    public void theEtagShouldBeUpdated() {
+        CompanyMetricsDocument updatedDocument = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        String eTag = updatedDocument.getCompanyMetrics().getEtag();
+        assertThat(eTag)
+                .isNotNull()
+                .isNotEqualTo(CONTEXT.get(ORIGINAL_ETAG));
+    }
+
+    @And("The updated object will have valid timestamp \\(UTC), type : {string} and by {string}")
+    public void theUpdatedObjectWillHaveValidValues(String type, String userId) {
+        CompanyMetricsDocument updatedDocument = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        Updated updated = updatedDocument.getUpdated();
+
+        assertThat(updated.getAt()).isAfterOrEqualTo((LocalDateTime) CONTEXT.get(START_TIME));
+        assertThat(updated.getBy()).isEqualTo(userId);
+        assertThat(updated.getType()).isEqualTo(type);
+    }
+
+    @Given("A company metrics resource exists for a company number of {string}")
+    public void aCompanyMetricsResourceExistsForACompanyNumberOf(String companyNumber) {
+        CONTEXT.set(COMPANY_NUMBER, companyNumber);
+
+        String eTag = UUID.randomUUID().toString();
+        CONTEXT.set(ORIGINAL_ETAG, eTag);
+
+        Updated updated = new Updated();
+        updated.setAt(LocalDateTime.now().minus(1, ChronoUnit.DAYS));
+        updated.setBy("Someone");
+        updated.setType(COMPANY_METRICS_TYPE);
+
+        CompanyMetricsDocument document = new CompanyMetricsDocument();
+        document.setId(companyNumber);
+        document.setCompanyMetrics(new MetricsApi()
+                .etag(eTag)
+                .counts(new CountsApi()
+                        .appointments(new AppointmentsApi()
+                                .activeCount(0)
+                                .activeDirectorsCount(1)
+                                .activeLlpMembersCount(0)
+                                .totalCount(0)
+                                .activeSecretariesCount(0)
+                                .resignedCount(0))
+                        .personsWithSignificantControl(new PscApi()
+                                .totalCount(0)
+                                .activePscsCount(0)
+                                .activeStatementsCount(0)
+                                .pscsCount(0)
+                                .statementsCount(0)
+                                .ceasedPscsCount(0)
+                                .withdrawnStatementsCount(0)))
+                .mortgage(new MortgageApi()
+                        .partSatisfiedCount(0)
+                        .satisfiedCount(1)
+                        .totalCount(1)));
+        document.setUpdated(updated);
+        companyMetricsRepository.save(document);
+    }
+
+    @And("The company has ACTIVE appointments for {int} directors, {int} secretaries, {int} LLP members, {int} Corp. LLP members")
+    public void theCompanyHasACTIVEAppointmentsFor(int activeDirectors, int activeSecretaries,
+            int activeLLPMembers, int activeCorporateLLPMembers) {
+        String companyNumber = CONTEXT.get(COMPANY_NUMBER).toString();
+
+        List<AppointmentDocument> documents = new ArrayList<>();
+        for (int i = 0; i < activeDirectors; i++) {
+            documents.add(buildAppointment(companyNumber, DIRECTOR));
+        }
+        for (int i = 0; i < activeSecretaries; i++) {
+            documents.add(buildAppointment(companyNumber, SECRETARY));
+        }
+        for (int i = 0; i < activeLLPMembers; i++) {
+            documents.add(buildAppointment(companyNumber, LLP_MEMBER));
+        }
+        for (int i = 0; i < activeCorporateLLPMembers; i++) {
+            documents.add(buildAppointment(companyNumber, CORPORATE_LLP_MEMBER));
+        }
+
+        appointmentRepository.saveAll(documents);
+    }
+
+    @And("The company has RESIGNED appointments for {int} directors, {int} secretaries, {int} LLP members, {int} Corp. LLP members")
+    public void theCompanyHasRESIGNEDAppointmentsFor(int resignedDirectors, int resignedSecretaries,
+            int resignedLLPMembers, int resignedCorporateLLPMembers) {
+        String companyNumber = CONTEXT.get(COMPANY_NUMBER).toString();
+
+        List<AppointmentDocument> documents = new ArrayList<>();
+        for (int i = 0; i < resignedDirectors; i++) {
+            documents.add(buildResignedAppointment(companyNumber, DIRECTOR));
+        }
+        for (int i = 0; i < resignedSecretaries; i++) {
+            documents.add(buildResignedAppointment(companyNumber, SECRETARY));
+        }
+        for (int i = 0; i < resignedLLPMembers; i++) {
+            documents.add(buildResignedAppointment(companyNumber, LLP_MEMBER));
+        }
+        for (int i = 0; i < resignedCorporateLLPMembers; i++) {
+            documents.add(buildResignedAppointment(companyNumber, CORPORATE_LLP_MEMBER));
+        }
+
+        appointmentRepository.saveAll(documents);
+    }
+
+    @And("The company has ZERO appointments registered")
+    public void theCompanyHasZEROAppointmentsRegistered() {
+        appointmentRepository.deleteAll();
+
+    }
+
+    @And("The appointments should have {int} active directors, {int} active secretaries, {int} active LLP members, {int} active Corp. LLP members, {int} total appointments, {int} active appointments, {int} resigned appointments")
+    public void theAppointmentsShouldHaveActiveOfficerCounts(int activeDirectors,
+            int activeSecretaries, int activeLLPMembers, int activeCorporateLLPMembers,
+            int totalCount, int activeCount, int resignedCount) {
+        CompanyMetricsDocument document = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        AppointmentsApi appointments = document.getCompanyMetrics().getCounts().getAppointments();
+
+        assertThat(appointments.getTotalCount()).isEqualTo(totalCount);
+        assertThat(appointments.getActiveCount()).isEqualTo(activeCount);
+        assertThat(appointments.getResignedCount()).isEqualTo(resignedCount);
+        assertThat(appointments.getActiveDirectorsCount()).isEqualTo(activeDirectors);
+        assertThat(appointments.getActiveSecretariesCount()).isEqualTo(activeSecretaries);
+        assertThat(appointments.getActiveLlpMembersCount()).isEqualTo(
+                activeLLPMembers + activeCorporateLLPMembers);
+    }
+
+    @Given("A company metrics resource exists for a company number of {string} but with no counts metrics")
+    public void aCompanyMetricsResourceExistsButNoAppointmentCounts(String companyNumber) {
+        CONTEXT.set(COMPANY_NUMBER, companyNumber);
+
+        String eTag = UUID.randomUUID().toString();
+        CONTEXT.set(ORIGINAL_ETAG, eTag);
+
+        Updated updated = new Updated();
+        updated.setAt(LocalDateTime.now().minus(1, ChronoUnit.DAYS));
+        updated.setBy("Someone");
+        updated.setType(COMPANY_METRICS_TYPE);
+
+        CompanyMetricsDocument document = new CompanyMetricsDocument();
+        document.setId(companyNumber);
+        document.setCompanyMetrics(new MetricsApi()
+                .etag(eTag)
+                .mortgage(new MortgageApi()
+                        .partSatisfiedCount(0)
+                        .satisfiedCount(1)
+                        .totalCount(1)));
+        document.setUpdated(updated);
+        companyMetricsRepository.save(document);
+    }
+
+    @Given("A company metrics resource exists for a company number of {string} with appointment counts that are all zero")
+    public void aCompanyMetricsResourceExistsButAppointmentCountsAllZero(String companyNumber) {
+        CONTEXT.set(COMPANY_NUMBER, companyNumber);
+
+        String eTag = UUID.randomUUID().toString();
+        CONTEXT.set(ORIGINAL_ETAG, eTag);
+
+        Updated updated = new Updated();
+        updated.setAt(LocalDateTime.now().minus(1, ChronoUnit.DAYS));
+        updated.setBy("Someone");
+        updated.setType(COMPANY_METRICS_TYPE);
+
+        CompanyMetricsDocument document = new CompanyMetricsDocument();
+        document.setId(companyNumber);
+        document.setCompanyMetrics(new MetricsApi()
+                .etag(eTag)
+                .counts(new CountsApi()
+                        .appointments(new AppointmentsApi()
+                                .activeCount(0)
+                                .activeDirectorsCount(1)
+                                .activeLlpMembersCount(0)
+                                .totalCount(0)
+                                .activeSecretariesCount(0)
+                                .resignedCount(0)))
+                .mortgage(new MortgageApi()
+                        .partSatisfiedCount(0)
+                        .satisfiedCount(1)
+                        .totalCount(1)));
+        document.setUpdated(updated);
+        companyMetricsRepository.save(document);
+    }
+
+    @And("The metrics resource does not have a count.appointments object")
+    public void theMetricsResourceDoesNotHaveACountAppointmentsObject() {
+        CompanyMetricsDocument document = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        assertThat(document.getCompanyMetrics().getCounts()).isNotNull();
+        assertThat(document.getCompanyMetrics().getCounts().getAppointments()).isNull();
+    }
+
+    @And("The metrics resource does not have a counts object")
+    public void theMetricsResourceDoesNotHaveACountObject() {
+        CompanyMetricsDocument document = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        assertThat(document.getCompanyMetrics().getCounts()).isNull();
+    }
+
+    @Given("A company metrics resource exists for a company number of {string} but no metrics")
+    public void aCompanyMetricsResourceExistsForACompanyNumberOfButNoMetrics(String companyNumber) {
+        CONTEXT.set(COMPANY_NUMBER, companyNumber);
+
+        String eTag = UUID.randomUUID().toString();
+        CONTEXT.set(ORIGINAL_ETAG, eTag);
+
+        Updated updated = new Updated();
+        updated.setAt(LocalDateTime.now().minus(1, ChronoUnit.DAYS));
+        updated.setBy("Someone");
+        updated.setType(COMPANY_METRICS_TYPE);
+
+        CompanyMetricsDocument document = new CompanyMetricsDocument();
+        document.setId(companyNumber);
+        document.setCompanyMetrics(new MetricsApi()
+                .etag(eTag));
+        document.setUpdated(updated);
+        companyMetricsRepository.save(document);
+    }
+
+    @And("The company metrics document has been deleted")
+    public void theCompanyMetricsDocumentDoesNotHaveAMetricsObject() {
+        CompanyMetricsDocument document = (CompanyMetricsDocument) CONTEXT.get(UPDATED_DOC);
+        assertThat(document).isNull();
+    }
+
+    private AppointmentDocument buildAppointment(String companyNumber, String role) {
+        Officer officer = new Officer()
+                .setOfficerRole(role);
+
+        return new AppointmentDocument()
+                .setCompanyNumber(companyNumber)
+                .setData(officer);
+    }
+
+    private AppointmentDocument buildResignedAppointment(String companyNumber, String role) {
+
+        AppointmentDocument appointmentDocument = buildAppointment(companyNumber, role);
+        appointmentDocument.getData()
+                .setResignedOn(Instant.now().minus(10, ChronoUnit.DAYS));
+        return appointmentDocument;
+    }
+}

--- a/src/itest/resources/features/company-metrics-appointments.feature
+++ b/src/itest/resources/features/company-metrics-appointments.feature
@@ -5,14 +5,14 @@ Feature: Appointments acceptance criteria
     And The company has ACTIVE appointments for <activeDirectors> directors, <activeSecretaries> secretaries, <activeLLPMembers> LLP members, <activeCorporateLLPMembers> Corp. LLP members
     And The company has RESIGNED appointments for <resignedDirectors> directors, <resignedSecretaries> secretaries, <resignedLLPMembers> LLP members, <resignedCorporateLLPMembers> Corp. LLP members
     And The user is authenticated and authorised with internal app privileges
-    When The recalculate endpoint is called by user "userId"
+    When The recalculate endpoint is called with updatedBy as "stream-partition-offset"
     Then The response code should be HTTP OK
     And The location response header should be "/company/0123456/metrics"
     And The response body should be empty
     And The metrics resource has a count.appointments object
     And The appointments should have <activeDirectors> active directors, <activeSecretaries> active secretaries, <activeLLPMembers> active LLP members, <activeCorporateLLPMembers> active Corp. LLP members, <totalCount> total appointments, <activeCount> active appointments, <resignedCount> resigned appointments
     And The etag should be updated
-    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+    And The updated object will have valid timestamp (UTC), type: "company_metrics" and by: "stream-partition-offset"
     Examples:
       | activeDirectors | activeSecretaries | activeLLPMembers | activeCorporateLLPMembers | resignedDirectors | resignedSecretaries | resignedLLPMembers | resignedCorporateLLPMembers | activeCount | totalCount | resignedCount |
       | 2               | 0                 | 0                | 0                         | 1                 | 0                   | 0                  | 0                           | 2           | 3          | 1             |
@@ -22,45 +22,63 @@ Feature: Appointments acceptance criteria
     And The company has ACTIVE appointments for <activeDirectors> directors, <activeSecretaries> secretaries, <activeLLPMembers> LLP members, <activeCorporateLLPMembers> Corp. LLP members
     And The company has RESIGNED appointments for <resignedDirectors> directors, <resignedSecretaries> secretaries, <resignedLLPMembers> LLP members, <resignedCorporateLLPMembers> Corp. LLP members
     And The user is authenticated and authorised with internal app privileges
-    When The recalculate endpoint is called by user "userId"
+    When The recalculate endpoint is called with updatedBy as "stream-partition-offset"
     Then The response code should be HTTP OK
     And The location response header should be "/company/0123456/metrics"
     And The response body should be empty
     And The metrics resource has a count.appointments object
     And The appointments should have <activeDirectors> active directors, <activeSecretaries> active secretaries, <activeLLPMembers> active LLP members, <activeCorporateLLPMembers> active Corp. LLP members, <totalCount> total appointments, <activeCount> active appointments, <resignedCount> resigned appointments
     And The etag should be updated
-    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+    And The updated object will have valid timestamp (UTC), type: "company_metrics" and by: "stream-partition-offset"
     Examples:
       | activeDirectors | activeSecretaries | activeLLPMembers | activeCorporateLLPMembers | resignedDirectors | resignedSecretaries | resignedLLPMembers | resignedCorporateLLPMembers | activeCount | totalCount | resignedCount |
       | 1               | 1                 | 0                | 0                         | 1                 | 0                   | 0                  | 0                           | 2           | 3          | 1             |
+
+  Scenario Outline: Update without an updatedBy value
+    Given A company metrics resource exists for a company number of "0123456"
+    And The company has ACTIVE appointments for <activeDirectors> directors, <activeSecretaries> secretaries, <activeLLPMembers> LLP members, <activeCorporateLLPMembers> Corp. LLP members
+    And The company has RESIGNED appointments for <resignedDirectors> directors, <resignedSecretaries> secretaries, <resignedLLPMembers> LLP members, <resignedCorporateLLPMembers> Corp. LLP members
+    And The user is authenticated and authorised with internal app privileges
+    When The recalculate endpoint is called with a context ID of "987654321" but without an updatedBy value
+    Then The response code should be HTTP OK
+    And The location response header should be "/company/0123456/metrics"
+    And The response body should be empty
+    And The metrics resource has a count.appointments object
+    And The appointments should have <activeDirectors> active directors, <activeSecretaries> active secretaries, <activeLLPMembers> active LLP members, <activeCorporateLLPMembers> active Corp. LLP members, <totalCount> total appointments, <activeCount> active appointments, <resignedCount> resigned appointments
+    And The etag should be updated
+    And The updated object will have valid timestamp (UTC), type: "company_metrics" and by: "contextId:987654321"
+    Examples:
+      | activeDirectors | activeSecretaries | activeLLPMembers | activeCorporateLLPMembers | resignedDirectors | resignedSecretaries | resignedLLPMembers | resignedCorporateLLPMembers | activeCount | totalCount | resignedCount |
+      | 1               | 1                 | 0                | 0                         | 1                 | 0                   | 0                  | 0                           | 2           | 3          | 1             |
+
 
   Scenario: Document Cleanup No appointments
     Given A company metrics resource exists for a company number of "0123456"
     And The company has ZERO appointments registered
     And The user is authenticated and authorised with internal app privileges
-    When The recalculate endpoint is called by user "userId"
+    When The recalculate endpoint is called with updatedBy as "stream-partition-offset"
     Then The response code should be HTTP OK
     And The location response header should be "/company/0123456/metrics"
     And The response body should be empty
     And The metrics resource does not have a count.appointments object
     And The etag should be updated
-    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+    And The updated object will have valid timestamp (UTC), type: "company_metrics" and by: "stream-partition-offset"
 
   Scenario: Document Cleanup No counts
     Given A company metrics resource exists for a company number of "0123456" but with no counts metrics
     And The user is authenticated and authorised with internal app privileges
-    When The recalculate endpoint is called by user "userId"
+    When The recalculate endpoint is called with updatedBy as "stream-partition-offset"
     Then The response code should be HTTP OK
     And The location response header should be "/company/0123456/metrics"
     And The response body should be empty
     And The metrics resource does not have a counts object
     And The etag should be updated
-    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+    And The updated object will have valid timestamp (UTC), type: "company_metrics" and by: "stream-partition-offset"
 
   Scenario: Document Cleanup No metrics
     Given A company metrics resource exists for a company number of "0123456" but no metrics
     And The user is authenticated and authorised with internal app privileges
-    When The recalculate endpoint is called by user "userId"
+    When The recalculate endpoint is called with updatedBy as "stream-partition-offset"
     Then The response code should be HTTP OK
     And The response body should be empty
     And The response should not include a location header

--- a/src/itest/resources/features/company-metrics-appointments.feature
+++ b/src/itest/resources/features/company-metrics-appointments.feature
@@ -1,0 +1,67 @@
+Feature: Appointments acceptance criteria
+
+  Scenario Outline: Create
+    Given A company metrics resource does not exist for a company number of "0123456"
+    And The company has ACTIVE appointments for <activeDirectors> directors, <activeSecretaries> secretaries, <activeLLPMembers> LLP members, <activeCorporateLLPMembers> Corp. LLP members
+    And The company has RESIGNED appointments for <resignedDirectors> directors, <resignedSecretaries> secretaries, <resignedLLPMembers> LLP members, <resignedCorporateLLPMembers> Corp. LLP members
+    And The user is authenticated and authorised with internal app privileges
+    When The recalculate endpoint is called by user "userId"
+    Then The response code should be HTTP OK
+    And The location response header should be "/company/0123456/metrics"
+    And The response body should be empty
+    And The metrics resource has a count.appointments object
+    And The appointments should have <activeDirectors> active directors, <activeSecretaries> active secretaries, <activeLLPMembers> active LLP members, <activeCorporateLLPMembers> active Corp. LLP members, <totalCount> total appointments, <activeCount> active appointments, <resignedCount> resigned appointments
+    And The etag should be updated
+    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+    Examples:
+      | activeDirectors | activeSecretaries | activeLLPMembers | activeCorporateLLPMembers | resignedDirectors | resignedSecretaries | resignedLLPMembers | resignedCorporateLLPMembers | activeCount | totalCount | resignedCount |
+      | 2               | 0                 | 0                | 0                         | 1                 | 0                   | 0                  | 0                           | 2           | 3          | 1             |
+
+  Scenario Outline: Update
+    Given A company metrics resource exists for a company number of "0123456"
+    And The company has ACTIVE appointments for <activeDirectors> directors, <activeSecretaries> secretaries, <activeLLPMembers> LLP members, <activeCorporateLLPMembers> Corp. LLP members
+    And The company has RESIGNED appointments for <resignedDirectors> directors, <resignedSecretaries> secretaries, <resignedLLPMembers> LLP members, <resignedCorporateLLPMembers> Corp. LLP members
+    And The user is authenticated and authorised with internal app privileges
+    When The recalculate endpoint is called by user "userId"
+    Then The response code should be HTTP OK
+    And The location response header should be "/company/0123456/metrics"
+    And The response body should be empty
+    And The metrics resource has a count.appointments object
+    And The appointments should have <activeDirectors> active directors, <activeSecretaries> active secretaries, <activeLLPMembers> active LLP members, <activeCorporateLLPMembers> active Corp. LLP members, <totalCount> total appointments, <activeCount> active appointments, <resignedCount> resigned appointments
+    And The etag should be updated
+    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+    Examples:
+      | activeDirectors | activeSecretaries | activeLLPMembers | activeCorporateLLPMembers | resignedDirectors | resignedSecretaries | resignedLLPMembers | resignedCorporateLLPMembers | activeCount | totalCount | resignedCount |
+      | 1               | 1                 | 0                | 0                         | 1                 | 0                   | 0                  | 0                           | 2           | 3          | 1             |
+
+  Scenario: Document Cleanup No appointments
+    Given A company metrics resource exists for a company number of "0123456"
+    And The company has ZERO appointments registered
+    And The user is authenticated and authorised with internal app privileges
+    When The recalculate endpoint is called by user "userId"
+    Then The response code should be HTTP OK
+    And The location response header should be "/company/0123456/metrics"
+    And The response body should be empty
+    And The metrics resource does not have a count.appointments object
+    And The etag should be updated
+    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+
+  Scenario: Document Cleanup No counts
+    Given A company metrics resource exists for a company number of "0123456" but with no counts metrics
+    And The user is authenticated and authorised with internal app privileges
+    When The recalculate endpoint is called by user "userId"
+    Then The response code should be HTTP OK
+    And The location response header should be "/company/0123456/metrics"
+    And The response body should be empty
+    And The metrics resource does not have a counts object
+    And The etag should be updated
+    And The updated object will have valid timestamp (UTC), type : "company_metrics" and by "userId"
+
+  Scenario: Document Cleanup No metrics
+    Given A company metrics resource exists for a company number of "0123456" but no metrics
+    And The user is authenticated and authorised with internal app privileges
+    When The recalculate endpoint is called by user "userId"
+    Then The response code should be HTTP OK
+    And The response body should be empty
+    And The response should not include a location header
+    And The company metrics document has been deleted

--- a/src/main/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsController.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsController.java
@@ -17,7 +17,6 @@ import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.MetricsRecalculateApi;
 import uk.gov.companieshouse.company.metrics.exceptions.BadRequestException;
 import uk.gov.companieshouse.company.metrics.exceptions.ServiceUnavailableException;
-import uk.gov.companieshouse.company.metrics.model.CompanyMetricsDocument;
 import uk.gov.companieshouse.company.metrics.service.CompanyMetricsService;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -69,12 +68,9 @@ public class CompanyMetricsController {
 
         try {
             BodyBuilder responseBuilder = ResponseEntity.ok();
-            CompanyMetricsDocument document = companyMetricsService.recalculateMetrics(contextId,
-                    companyNumber, requestBody);
-            if (document != null) {
-                responseBuilder
-                        .header(LOCATION, String.format("/company/%s/metrics", companyNumber));
-            }
+            companyMetricsService.recalculateMetrics(contextId, companyNumber, requestBody)
+                    .ifPresent(companyMetricsDocument -> responseBuilder
+                            .header(LOCATION, String.format("/company/%s/metrics", companyNumber)));
             return responseBuilder.build();
         } catch (DataAccessResourceFailureException ex) {
             throw new ServiceUnavailableException("Database unavailable");

--- a/src/main/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsController.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity.BodyBuilder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,9 +17,9 @@ import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.MetricsRecalculateApi;
 import uk.gov.companieshouse.company.metrics.exceptions.BadRequestException;
 import uk.gov.companieshouse.company.metrics.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.company.metrics.model.CompanyMetricsDocument;
 import uk.gov.companieshouse.company.metrics.service.CompanyMetricsService;
 import uk.gov.companieshouse.logging.Logger;
-
 
 @RestController
 public class CompanyMetricsController {
@@ -27,7 +28,7 @@ public class CompanyMetricsController {
     private final Logger logger;
 
     public CompanyMetricsController(Logger logger,
-                                    CompanyMetricsService companyMetricsService) {
+            CompanyMetricsService companyMetricsService) {
         this.logger = logger;
         this.companyMetricsService = companyMetricsService;
     }
@@ -52,31 +53,34 @@ public class CompanyMetricsController {
     /**
      * Post request for company metrics.
      *
-     * @param  companyNumber  the company number for metrics recalculation
-     * @param  requestBody  the request body containing Instructions to recalculate
-     * @return  no response
+     * @param companyNumber the company number for metrics recalculation
+     * @param requestBody   the request body containing Instructions to recalculate
+     * @return no response
      */
-    @PostMapping ("/company/{company_number}/metrics/recalculate")
+    @PostMapping("/company/{company_number}/metrics/recalculate")
     public ResponseEntity<Void> recalculate(
             @RequestHeader("x-request-id") String contextId,
-             @PathVariable("company_number") String companyNumber,
-             @Valid @RequestBody MetricsRecalculateApi requestBody) throws BadRequestException {
+            @PathVariable("company_number") String companyNumber,
+            @Valid @RequestBody MetricsRecalculateApi requestBody) throws BadRequestException {
         logger.info(String.format(
                 "Payload Successfully received on POST with context id %s and company number %s",
                 contextId,
                 companyNumber));
 
         try {
-            companyMetricsService.recalculateMetrics(contextId, companyNumber, requestBody);
-            return ResponseEntity
-                    .ok()
-                    .header(LOCATION, String.format("/company/%s/metrics", companyNumber))
-                    .build();
+            BodyBuilder responseBuilder = ResponseEntity.ok();
+            CompanyMetricsDocument document = companyMetricsService.recalculateMetrics(contextId,
+                    companyNumber, requestBody);
+            if (document != null) {
+                responseBuilder
+                        .header(LOCATION, String.format("/company/%s/metrics", companyNumber));
+            }
+            return responseBuilder.build();
         } catch (DataAccessResourceFailureException ex) {
             throw new ServiceUnavailableException("Database unavailable");
         } catch (IllegalArgumentException ex) {
             throw new BadRequestException(String.format("Invalid Request Received. %s ",
-                requestBody == null ? null : requestBody.toString()));
+                    requestBody == null ? null : requestBody.toString()));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
@@ -57,7 +57,7 @@ public class CompanyMetricsService {
      * @param companyNumber      The ID of the company to update metrics for
      * @param recalculateRequest Request data that determines which metrics to update
      */
-    public CompanyMetricsDocument recalculateMetrics(String contextId,
+    public Optional<CompanyMetricsDocument> recalculateMetrics(String contextId,
             String companyNumber,
             MetricsRecalculateApi recalculateRequest) {
 
@@ -96,12 +96,12 @@ public class CompanyMetricsService {
             logger.info(String.format("Company metrics updated for context id %s with id %s",
                     contextId, companyMetricsDocument.getId()));
             companyMetricsRepository.save(companyMetricsDocument);
-            return companyMetricsDocument;
+            return Optional.of(companyMetricsDocument);
         } else {
             companyMetricsRepository.delete(companyMetricsDocument);
             logger.info(String.format("Empty company metrics deleted for context id %s with id %s",
                     contextId, companyMetricsDocument.getId()));
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
@@ -58,7 +58,7 @@ public class CompanyMetricsService {
      * @param companyNumber         The ID of the company to update metrics for
      * @param recalculateRequest Request data that determines which metrics to update
      */
-    public void recalculateMetrics(String contextId,
+    public CompanyMetricsDocument recalculateMetrics(String contextId,
             String companyNumber,
             MetricsRecalculateApi recalculateRequest) {
 
@@ -93,13 +93,15 @@ public class CompanyMetricsService {
                     ? recalculateRequest.getInternalData().getUpdatedBy() : null;
             companyMetricsDocument.setUpdated(populateUpdated(updatedBy));
 
-            companyMetricsRepository.save(companyMetricsDocument);
             logger.info(String.format("Company metrics updated for context id %s with id %s",
                     contextId, companyMetricsDocument.getId()));
+            companyMetricsRepository.save(companyMetricsDocument);
+            return companyMetricsDocument;
         } else {
             companyMetricsRepository.delete(companyMetricsDocument);
             logger.info(String.format("Empty company metrics deleted for context id %s with id %s",
                     contextId, companyMetricsDocument.getId()));
+            return null;
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
@@ -44,8 +44,7 @@ public class CompanyMetricsService {
      * Retrieve company metrics using its company number.
      *
      * @param companyNumber the company number
-     * @return company metrics, if one with such a company number exists, otherwise an empty
-     *         optional
+     * @return company metrics, if the company number exists, otherwise an empty optional
      */
     public Optional<CompanyMetricsDocument> get(String companyNumber) {
         return companyMetricsRepository.findById(companyNumber);
@@ -54,8 +53,8 @@ public class CompanyMetricsService {
     /**
      * Save or Update company_metrics.
      *
-     * @param contextId             Request context ID
-     * @param companyNumber         The ID of the company to update metrics for
+     * @param contextId          Request context ID
+     * @param companyNumber      The ID of the company to update metrics for
      * @param recalculateRequest Request data that determines which metrics to update
      */
     public CompanyMetricsDocument recalculateMetrics(String contextId,
@@ -91,7 +90,8 @@ public class CompanyMetricsService {
 
             String updatedBy = recalculateRequest.getInternalData() != null
                     ? recalculateRequest.getInternalData().getUpdatedBy() : null;
-            companyMetricsDocument.setUpdated(populateUpdated(updatedBy));
+            companyMetricsDocument.setUpdated(populateUpdated(
+                    updatedBy != null ? updatedBy : String.format("contextId:%s", contextId)));
 
             logger.info(String.format("Company metrics updated for context id %s with id %s",
                     contextId, companyMetricsDocument.getId()));

--- a/src/test/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsControllerTest.java
@@ -137,7 +137,7 @@ class CompanyMetricsControllerTest {
     void postRecalculateCompanyAppointments() throws Exception {
 
         when(companyMetricsService.recalculateMetrics(anyString(), anyString(), any()))
-                .thenReturn(new CompanyMetricsDocument());
+                .thenReturn(Optional.of(new CompanyMetricsDocument()));
 
         MetricsRecalculateApi requestBody = testData.populateMetricsRecalculateApiForAppointments();
 

--- a/src/test/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/controller/CompanyMetricsControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company.metrics.controller;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -29,6 +30,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.metrics.MetricsRecalculateApi;
 import uk.gov.companieshouse.company.metrics.config.ApplicationConfig;
+import uk.gov.companieshouse.company.metrics.model.CompanyMetricsDocument;
 import uk.gov.companieshouse.company.metrics.model.TestData;
 import uk.gov.companieshouse.company.metrics.service.CompanyMetricsService;
 import uk.gov.companieshouse.logging.Logger;
@@ -134,6 +136,9 @@ class CompanyMetricsControllerTest {
     @DisplayName("Post call to recalculate company appointments and update metrics")
     void postRecalculateCompanyAppointments() throws Exception {
 
+        when(companyMetricsService.recalculateMetrics(anyString(), anyString(), any()))
+                .thenReturn(new CompanyMetricsDocument());
+
         MetricsRecalculateApi requestBody = testData.populateMetricsRecalculateApiForAppointments();
 
         mockMvc.perform(post(RECALCULATE_URL)
@@ -145,6 +150,25 @@ class CompanyMetricsControllerTest {
                         .content(gson.toJson(requestBody)))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/company/12345678/metrics"));
+        verify(companyMetricsService).recalculateMetrics(eq("5342342"), eq(MOCK_COMPANY_NUMBER),
+                any());
+    }
+
+    @Test
+    @DisplayName("Post call to recalculate metrics that results in empty metrics has an empty LOCATION header")
+    void postRecalculateCompanyMetricsWithEmptyResultsHasNoLocationHeader() throws Exception {
+
+        MetricsRecalculateApi requestBody = testData.populateMetricsRecalculateApiForAppointments();
+
+        mockMvc.perform(post(RECALCULATE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header(X_REQUEST_ID, "5342342")
+                        .header(ERIC_IDENTITY, "SOME_IDENTITY")
+                        .header(ERIC_IDENTITY_TYPE, "key")
+                        .header(ERIC_AUTHORISED_KEY_PRIVILEGES, "internal-app")
+                        .content(gson.toJson(requestBody)))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist(HttpHeaders.LOCATION));
         verify(companyMetricsService).recalculateMetrics(eq("5342342"), eq(MOCK_COMPANY_NUMBER),
                 any());
     }


### PR DESCRIPTION
* Implemented Cucumber tests from the acceptance criteria
* Fixed a bug where a LOCATION header was being returned from an HTTP recalculate request that deleted the company metrics document
* Updated the CucumberContext to be able to clear values before test runs
* Changed the way the `updatedBy` field in the `company_metrics` collection is populated. It now uses the value in the API request by default, or the `contextId` if this is missing
[DSND-1554](https://companieshouse.atlassian.net/browse/DSND-1554)

[DSND-1554]: https://companieshouse.atlassian.net/browse/DSND-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ