### PR TITLE
DSND-3007: Fix bug when deleting a document for a company that does not exist

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsServiceVersionedDocumentITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsServiceVersionedDocumentITest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.company.metrics.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +30,10 @@ class CompanyMetricsServiceVersionedDocumentITest extends AbstractIntegrationTes
     private static final MortgageApi MORTGAGES = new MortgageApi()
             .totalCount(1)
             .satisfiedCount(1)
+            .partSatisfiedCount(0);
+    private static final MortgageApi EMPTY_MORTGAGES = new MortgageApi()
+            .totalCount(0)
+            .satisfiedCount(0)
             .partSatisfiedCount(0);
     private final TestData testData = new TestData();
 
@@ -119,5 +124,19 @@ class CompanyMetricsServiceVersionedDocumentITest extends AbstractIntegrationTes
 
         assertNotNull(document.get().getCompanyMetrics().getMortgage());
         assertNotNull(document.get().getCompanyMetrics().getEtag());
+    }
+
+
+    @Test
+    void shouldDeleteDocumentForMissingCompanyNumber() {
+        when(chargesCountService.recalculateMetrics(any()))
+                .thenReturn(EMPTY_MORTGAGES);
+
+        companyMetricsService.recalculateMetrics(CONTEXT_ID, COMPANY_NUMBER,
+                testData.populateMetricsRecalculateApiForCharges());
+
+        Optional<CompanyMetricsDocument> document = companyMetricsRepository.findById(COMPANY_NUMBER);
+
+        assertFalse(document.isPresent());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsService.java
@@ -124,7 +124,7 @@ public class CompanyMetricsService {
             companyMetricsDocument.setUpdated(populateUpdated(
                     updatedBy != null ? updatedBy : String.format("contextId:%s", contextId)));
 
-            logger.info("Company metrics updated", DataMapHolder.getLogMap());
+            logger.info("Updating company metrics", DataMapHolder.getLogMap());
             if (companyMetricsDocument.getId() == null) { // A new document
                 companyMetricsDocument.setId(companyNumber);
                 companyMetricsRepository.insert(companyMetricsDocument);
@@ -135,8 +135,8 @@ public class CompanyMetricsService {
             }
             return Optional.of(companyMetricsDocument);
         } else {
-            companyMetricsRepository.delete(companyMetricsDocument);
-            logger.info("Empty company metrics deleted", DataMapHolder.getLogMap());
+            logger.info("Deleting empty company metrics document", DataMapHolder.getLogMap());
+            companyMetricsRepository.deleteById(companyNumber);
             return Optional.empty();
         }
     }

--- a/src/test/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/service/CompanyMetricsServiceTest.java
@@ -515,7 +515,7 @@ class CompanyMetricsServiceTest {
         verify(pscsCountService, never()).recalculateMetrics(any());
 
 
-        verify(companyMetricsRepository).delete(companyMetricsDocumentCaptor.capture());
+        verify(companyMetricsRepository).deleteById(any());
     }
 
     @Test


### PR DESCRIPTION

* Changed delete operation to use `companyMetricsRepository.deleteById()`
* Updated logging to make things more readable