### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 artifact_name       := company-metrics-api
 version             := unversioned
 
+dependency_check_base_suppressions:=common_suppressions_spring_6.xml
+dependency_check_suppressions_repo_branch:=main
+dependency_check_minimum_cvss := 4
+dependency_check_assembly_analyzer_enabled := false
+dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
+suppressions_file := target/suppressions.xml
+
 ## Create help from comments in Makefile
 help:
 	@printf "%-20s %s\n" "Target" "Description"
@@ -33,11 +40,6 @@ build:
 	$(info Packing version: $(version))
 	mvn package -Dmaven.test.skip=true
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
-
-.PHONY: security-check
-security-check:
-	mvn org.owasp:dependency-check-maven:update-only
-	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false
 
 .PHONY: test
 test: test-integration test-unit
@@ -99,5 +101,35 @@ lint/docker-compose:
 	@# Help: Lint docker file
 	docker-compose -f docker-compose.yml config
 
+.PHONY: dependency-check
+dependency-check:
+	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+		suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
+	fi; \
+	if [ ! -d "$${suppressions_home}" ]; then \
+	    suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
+			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
+			if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
+				cd "$${suppressions_home}"; \
+				git checkout $(dependency_check_suppressions_repo_branch); \
+				cd -; \
+			fi; \
+		fi; \
+	fi; \
+	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
+	if [  -f "$${suppressions_path}" ]; then \
+		cp -av "$${suppressions_path}" $(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+	else \
+		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
+		exit 1; \
+	fi
 
+.PHONY: security-check
+security-check: dependency-check
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.11</version>
+		<relativePath/>
 	</parent>
 
 	<artifactId>company-metrics-api</artifactId>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-</suppressions>


### PR DESCRIPTION
cacee39 Remove defunct suppress.xml
The suppress.xml file is now pulled from the
 dependency-check-suppressions repo.

37df2b1 Repoint Makefile at dep-check-suppressions/main
The 'dependency-check' target uses a variable
  dependency_check_suppressions_repo_branch
 which previously pointed to a different branch:
  feature/suppressions-for-company-accounts-api
 ... but that branch has been merged into main and so this variable
 should now point to main.
Tidy Makefile for dependency-check consistency
Make line spacing, ordering, format for dependency-check sections
 identical across Makefiles.
Add json to dependency check report formats.

b2c8c46 Update parent pom to 2.1.11, use relativePath
2.1.11 brings in latest correct dependency-check settings.
relativePath prevents Maven from searching locally for the parent pom,
 forcing it to go to the standard Maven repositories.

Fixes https://companieshouse.atlassian.net/browse/CC-1876