### PR TITLE
ASM-2038: Test MongoDB 8 compatibility for company-metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
         <main.class>uk.gov.companieshouse.company.metrics.CompanyMetricsApiApplication</main.class>
 
-        <spring.boot.version>3.5.7</spring.boot.version>
+        <spring.boot.version>3.5.14</spring.boot.version>
 
         <!-- Internal -->
         <structured-logging.version>3.0.43</structured-logging.version>

--- a/src/itest/java/uk/gov/companieshouse/company/metrics/config/AbstractMongoConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/config/AbstractMongoConfig.java
@@ -15,7 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 public class AbstractMongoConfig {
 
     public static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-            DockerImageName.parse("mongo:7.0.17"));
+            DockerImageName.parse("mongo:8"));
 
     @DynamicPropertySource
     public static void setProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
- Updated MongoDB test containers to 8
- Tidied up POM and removed unused CVE fixes

[ASM-2038](https://companieshouse.atlassian.net/browse/ASM-2038)

[ASM-2038]: https://companieshouse.atlassian.net/browse/ASM-2038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ