### PR TITLE
asm-2463 - fix sec vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
 
@@ -21,7 +21,7 @@
 
         <main.class>uk.gov.companieshouse.company.metrics.CompanyMetricsApiApplication</main.class>
 
-        <spring.boot.version>3.5.14</spring.boot.version>
+        <spring.boot.version>3.5.15</spring.boot.version>
 
         <!-- Internal -->
         <structured-logging.version>3.0.43</structured-logging.version>
@@ -58,23 +58,42 @@
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
 
+        <log4j2.version>2.26.0</log4j2.version>
+
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-bom</artifactId>
+            <version>${log4j2.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
 
         <!--Transitive deps start here-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.19.0</version>
+            <version>3.20.0</version>
         </dependency>
         <!--end transitive dependencies-->
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
[ASM-2463](https://companieshouse.atlassian.net/browse/ASM-2463)


Updated parent pom version
Uplifted spring boot version
Introduced log4j bom version
Excluded vulnerable log4j artifcats from spring-boot-starter

[ASM-2463]: https://companieshouse.atlassian.net/browse/ASM-2463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ